### PR TITLE
Make GitHub detect *.spf as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.spf linguist-language=Forth


### PR DESCRIPTION
Hello,

This makes GitHub recognize the `.spf` files as Forth.